### PR TITLE
cache unsettled NetworkQos to avoid race condition

### DIFF
--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_namespace.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_namespace.go
@@ -56,7 +56,7 @@ func (c *Controller) syncNetworkQoSNamespace(key string) error {
 	if namespace == nil {
 		for _, cachedKey := range c.nqosCache.GetKeys() {
 			err := c.nqosCache.DoWithLock(cachedKey, func(nqosKey string) error {
-				if nqosObj, loaded := c.nqosCache.Load(nqosKey); loaded {
+				if nqosObj, _ := c.nqosCache.Load(nqosKey); nqosObj != nil {
 					return c.clearNamespaceForNQOS(key, nqosObj)
 				}
 				return nil
@@ -71,7 +71,7 @@ func (c *Controller) syncNetworkQoSNamespace(key string) error {
 	// case (i)/(ii)
 	for _, cachedKey := range c.nqosCache.GetKeys() {
 		err := c.nqosCache.DoWithLock(cachedKey, func(nqosKey string) error {
-			if nqosObj, loaded := c.nqosCache.Load(nqosKey); loaded {
+			if nqosObj, _ := c.nqosCache.Load(nqosKey); nqosObj != nil {
 				return c.setNamespaceForNQOS(namespace, nqosObj)
 			} else {
 				klog.Warningf("NetworkQoS not synced yet: %s", nqosKey)

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_node.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_node.go
@@ -75,8 +75,8 @@ func (c *Controller) syncNetworkQoSNode(key string) error {
 	}
 	for _, cachedKey := range c.nqosCache.GetKeys() {
 		err := c.nqosCache.DoWithLock(cachedKey, func(nqosKey string) error {
-			nqosObj, loaded := c.nqosCache.Load(nqosKey)
-			if !loaded {
+			nqosObj, _ := c.nqosCache.Load(nqosKey)
+			if nqosObj == nil {
 				klog.Warningf("NetworkQoS not synced yet: %s", nqosKey)
 				// requeue nqos key to sync it
 				c.nqosQueue.Add(nqosKey)

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_pod.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_pod.go
@@ -73,7 +73,7 @@ func (c *Controller) syncNetworkQoSPod(key string) error {
 	if pod == nil || util.PodCompleted(pod) {
 		for _, cachedKey := range c.nqosCache.GetKeys() {
 			err := c.nqosCache.DoWithLock(cachedKey, func(nqosKey string) error {
-				if nqosObj, loaded := c.nqosCache.Load(nqosKey); loaded {
+				if nqosObj, _ := c.nqosCache.Load(nqosKey); nqosObj != nil {
 					return c.clearPodForNQOS(namespace, name, nqosObj)
 				}
 				return nil
@@ -97,7 +97,7 @@ func (c *Controller) syncNetworkQoSPod(key string) error {
 	// case (i)/(ii)
 	for _, cachedKey := range c.nqosCache.GetKeys() {
 		err := c.nqosCache.DoWithLock(cachedKey, func(nqosKey string) error {
-			if nqosObj, loaded := c.nqosCache.Load(nqosKey); loaded {
+			if nqosObj, _ := c.nqosCache.Load(nqosKey); nqosObj != nil {
 				return c.setPodForNQOS(pod, nqosObj, ns)
 			} else {
 				klog.Warningf("NetworkQoS not synced yet: %s", nqosKey)


### PR DESCRIPTION
add unsettled networkqos key to controller cache, so that pod handler can see the in-progress NetworkQos objects, and lock the objects to avoid race condition.
