### PR TITLE
refactor networkqos handlers

### DIFF
--- a/dist/templates/k8s.ovn.org_networkqoses.yaml.j2
+++ b/dist/templates/k8s.ovn.org_networkqoses.yaml.j2
@@ -637,6 +637,9 @@ spec:
                 x-kubernetes-validations:
                 - message: networkSelector is immutable
                   rule: self == oldSelf
+                - message: Unsupported network selection type
+                  rule: self.all(sel, sel.networkSelectionType == 'ClusterUserDefinedNetworks'
+                    || sel.networkSelectionType == 'NetworkAttachmentDefinitions')
               podSelector:
                 description: |-
                   podSelector applies the NetworkQoS rule only to the pods in the namespace whose label

--- a/go-controller/pkg/crd/networkqos/v1alpha1/types.go
+++ b/go-controller/pkg/crd/networkqos/v1alpha1/types.go
@@ -50,6 +50,7 @@ type Spec struct {
 	// NetworkQoS controller currently supports `NetworkAttachmentDefinitions` type only.
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkSelector is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.all(sel, sel.networkSelectionType == 'ClusterUserDefinedNetworks' || sel.networkSelectionType == 'NetworkAttachmentDefinitions')", message="Unsupported network selection type"
 	NetworkSelectors crdtypes.NetworkSelectors `json:"networkSelectors,omitempty"`
 
 	// podSelector applies the NetworkQoS rule only to the pods in the namespace whose label

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos.go
@@ -8,22 +8,22 @@ import (
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
+	networkqosapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/networkqos/v1alpha1"
+	nqosapiapply "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/networkqos/v1alpha1/apis/applyconfiguration/networkqos/v1alpha1"
+	crdtypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/types"
+	udnv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
-
-	networkqosapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/networkqos/v1alpha1"
-	nqosapiapply "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/networkqos/v1alpha1/apis/applyconfiguration/networkqos/v1alpha1"
-	crdtypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/types"
-	udnv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
 func (c *Controller) processNextNQOSWorkItem(wg *sync.WaitGroup) bool {
@@ -35,18 +35,14 @@ func (c *Controller) processNextNQOSWorkItem(wg *sync.WaitGroup) bool {
 	}
 	defer c.nqosQueue.Done(nqosKey)
 
-	err := c.syncNetworkQoS(nqosKey)
-	if err == nil {
-		c.nqosQueue.Forget(nqosKey)
-		return true
+	if err := c.syncNetworkQoS(nqosKey); err != nil {
+		if c.nqosQueue.NumRequeues(nqosKey) < maxRetries {
+			c.nqosQueue.AddRateLimited(nqosKey)
+			return true
+		}
+		klog.Warningf("%s: Failed to reconcile NetworkQoS %s: %v", c.controllerName, nqosKey, err)
+		utilruntime.HandleError(fmt.Errorf("failed to reconcile NetworkQoS %s: %v", nqosKey, err))
 	}
-	utilruntime.HandleError(fmt.Errorf("%s: failed to handle key %s, error: %v", c.controllerName, nqosKey, err))
-
-	if c.nqosQueue.NumRequeues(nqosKey) < maxRetries {
-		c.nqosQueue.AddRateLimited(nqosKey)
-		return true
-	}
-
 	c.nqosQueue.Forget(nqosKey)
 	return true
 }
@@ -59,12 +55,11 @@ func (c *Controller) syncNetworkQoS(key string) error {
 	if err != nil {
 		return err
 	}
-	klog.V(5).Infof("%s - Processing sync for Network QoS %s", c.controllerName, nqosName)
-
 	defer func() {
-		klog.V(5).Infof("%s - Finished syncing Network QoS %s : %v", c.controllerName, nqosName, time.Since(startTime))
+		klog.V(5).Infof("%s - Finished reconciling NetworkQoS %s : %v", c.controllerName, nqosName, time.Since(startTime))
 	}()
 
+	klog.V(5).Infof("%s - reconciling NetworkQoS %s", c.controllerName, nqosName)
 	nqos, err := c.nqosLister.NetworkQoSes(nqosNamespace).Get(nqosName)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
@@ -280,22 +275,31 @@ func (c *Controller) resyncPods(nqosState *networkQoSState) error {
 		return fmt.Errorf("failed to list pods in namespace %s: %w", nqosState.namespace, err)
 	}
 	nsCache := make(map[string]*corev1.Namespace)
+	addressSetMap := map[string]sets.Set[string]{}
 	for _, pod := range pods {
-		if pod.Spec.HostNetwork {
+		if pod.Spec.HostNetwork || pod.DeletionTimestamp != nil {
 			continue
 		}
 		ns := nsCache[pod.Namespace]
 		if ns == nil {
 			ns, err = c.nqosNamespaceLister.Get(pod.Namespace)
 			if err != nil {
+				if apierrors.IsNotFound(err) {
+					klog.Warningf("Namespace %s not found, skipping pod %s/%s", pod.Namespace, pod.Namespace, pod.Name)
+					continue
+				}
 				return fmt.Errorf("failed to get namespace %s: %w", pod.Namespace, err)
 			}
 			nsCache[pod.Namespace] = ns
 		}
-		if err := c.setPodForNQOS(pod, nqosState, ns); err != nil {
+		if ns.DeletionTimestamp != nil {
+			continue
+		}
+		if err := c.setPodForNQOS(pod, nqosState, ns, addressSetMap); err != nil {
 			return err
 		}
 	}
+	nqosState.cleanupStaleAddresses(addressSetMap)
 	return nil
 }
 
@@ -307,16 +311,16 @@ func (c *Controller) networkManagedByMe(networkSelectors crdtypes.NetworkSelecto
 		return c.IsDefault(), nil
 	}
 	var selectedNads []*nadv1.NetworkAttachmentDefinition
+	var err error
 	for _, networkSelector := range networkSelectors {
 		switch networkSelector.NetworkSelectionType {
 		case crdtypes.DefaultNetwork:
 			return c.IsDefault(), nil
 		case crdtypes.ClusterUserDefinedNetworks:
-			nadSelector, err := metav1.LabelSelectorAsSelector(&networkSelector.ClusterUserDefinedNetworkSelector.NetworkSelector)
-			if err != nil {
-				return false, err
+			if networkSelector.ClusterUserDefinedNetworkSelector == nil {
+				return false, fmt.Errorf("empty cluster user defined network selector")
 			}
-			nads, err := c.nadLister.List(nadSelector)
+			nads, err := c.getNetAttachDefsBySelectors(nil, &networkSelector.ClusterUserDefinedNetworkSelector.NetworkSelector)
 			if err != nil {
 				return false, err
 			}
@@ -333,37 +337,9 @@ func (c *Controller) networkManagedByMe(networkSelectors crdtypes.NetworkSelecto
 			if networkSelector.NetworkAttachmentDefinitionSelector == nil {
 				return false, fmt.Errorf("empty network attachment definition selector")
 			}
-			nadSelector, err := metav1.LabelSelectorAsSelector(&networkSelector.NetworkAttachmentDefinitionSelector.NetworkSelector)
+			selectedNads, err = c.getNetAttachDefsBySelectors(&networkSelector.NetworkAttachmentDefinitionSelector.NamespaceSelector, &networkSelector.NetworkAttachmentDefinitionSelector.NetworkSelector)
 			if err != nil {
 				return false, err
-			}
-			if nadSelector.Empty() {
-				return false, fmt.Errorf("empty network selector")
-			}
-			nsSelector, err := metav1.LabelSelectorAsSelector(&networkSelector.NetworkAttachmentDefinitionSelector.NamespaceSelector)
-			if err != nil {
-				return false, err
-			}
-
-			if nsSelector.Empty() {
-				// if namespace selector is empty, list NADs in all namespaces
-				nads, err := c.nadLister.List(nadSelector)
-				if err != nil {
-					return false, err
-				}
-				selectedNads = append(selectedNads, nads...)
-			} else {
-				namespaces, err := c.nqosNamespaceLister.List(nsSelector)
-				if err != nil {
-					return false, err
-				}
-				for _, ns := range namespaces {
-					nads, err := c.nadLister.NetworkAttachmentDefinitions(ns.Name).List(nadSelector)
-					if err != nil {
-						return false, err
-					}
-					selectedNads = append(selectedNads, nads...)
-				}
 			}
 		default:
 			return false, fmt.Errorf("unsupported network selection type %s", networkSelector.NetworkSelectionType)
@@ -393,4 +369,52 @@ func (c *Controller) getLogicalSwitchName(nodeName string) string {
 	default:
 		return ""
 	}
+}
+
+func (c *Controller) getAllNetworkQoSes() ([]*networkqosapi.NetworkQoS, error) {
+	nqoses, err := c.nqosLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list NetworkQoS: %v", err)
+	}
+	return nqoses, nil
+}
+
+func (c *Controller) getNetAttachDefsBySelectors(namespaceSelector, nadSelector *metav1.LabelSelector) ([]*nadv1.NetworkAttachmentDefinition, error) {
+	if nadSelector == nil || nadSelector.Size() == 0 {
+		return nil, fmt.Errorf("empty network selector")
+	}
+	nadSel, err := metav1.LabelSelectorAsSelector(nadSelector)
+	if err != nil {
+		return nil, fmt.Errorf("invalid network selector %v: %v", nadSelector.String(), err)
+	}
+	namespaces := []*corev1.Namespace{}
+	if namespaceSelector != nil && namespaceSelector.Size() > 0 {
+		nsSelector, err := metav1.LabelSelectorAsSelector(namespaceSelector)
+		if err != nil {
+			return nil, fmt.Errorf("invalid namespace selector %v: %v", namespaceSelector.String(), err)
+		}
+		namespaces, err = c.nqosNamespaceLister.List(nsSelector)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list namespaces: %v", err)
+		}
+	}
+
+	var selectedNads []*nadv1.NetworkAttachmentDefinition
+	if len(namespaces) == 0 {
+		// if namespace selector is empty, list NADs in all namespaces
+		nads, err := c.nadLister.List(nadSel)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list NADs: %v", err)
+		}
+		selectedNads = append(selectedNads, nads...)
+	} else {
+		for _, ns := range namespaces {
+			nads, err := c.nadLister.NetworkAttachmentDefinitions(ns.Name).List(nadSel)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list NADs in namespace %s: %v", ns.Name, err)
+			}
+			selectedNads = append(selectedNads, nads...)
+		}
+	}
+	return selectedNads, nil
 }

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_controller.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_controller.go
@@ -10,6 +10,7 @@ import (
 	nadlisterv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -66,9 +67,10 @@ type Controller struct {
 	// store's the name of the zone that this controller belongs to
 	zone string
 
-	// nqos namespace+name is key -> cloned value of NQOS kapi is value
-	//nqosCache map[string]*networkQoSState
+	// namespace+name -> cloned value of NetworkQoS
 	nqosCache *syncmap.SyncMap[*networkQoSState]
+	// lock for nqosCache
+	nqosCacheLock sync.RWMutex
 
 	// queues for the CRDs where incoming work is placed to de-dup
 	nqosQueue workqueue.TypedRateLimitingInterface[string]
@@ -78,11 +80,11 @@ type Controller struct {
 	// namespace queue, cache, lister
 	nqosNamespaceLister corev1listers.NamespaceLister
 	nqosNamespaceSynced cache.InformerSynced
-	nqosNamespaceQueue  workqueue.TypedRateLimitingInterface[string]
+	nqosNamespaceQueue  workqueue.TypedRateLimitingInterface[*eventData[*corev1.Namespace]]
 	// pod queue, cache, lister
 	nqosPodLister corev1listers.PodLister
 	nqosPodSynced cache.InformerSynced
-	nqosPodQueue  workqueue.TypedRateLimitingInterface[string]
+	nqosPodQueue  workqueue.TypedRateLimitingInterface[*eventData[*corev1.Pod]]
 	// node queue, cache, lister
 	nqosNodeLister corev1listers.NodeLister
 	nqosNodeSynced cache.InformerSynced
@@ -91,6 +93,36 @@ type Controller struct {
 	// nad lister, only valid for default network controller when multi-network is enabled
 	nadLister nadlisterv1.NetworkAttachmentDefinitionLister
 	nadSynced cache.InformerSynced
+}
+
+type eventData[T metav1.Object] struct {
+	old T
+	new T
+}
+
+func newEventData[T metav1.Object](old T, new T) *eventData[T] {
+	return &eventData[T]{
+		old: old,
+		new: new,
+	}
+}
+
+func (e *eventData[T]) name() string {
+	if !reflect.ValueOf(e.old).IsNil() {
+		return e.old.GetName()
+	} else if !reflect.ValueOf(e.new).IsNil() {
+		return e.new.GetName()
+	}
+	return ""
+}
+
+func (e *eventData[T]) namespace() string {
+	if !reflect.ValueOf(e.old).IsNil() {
+		return e.old.GetNamespace()
+	} else if !reflect.ValueOf(e.new).IsNil() {
+		return e.new.GetNamespace()
+	}
+	return ""
 }
 
 // NewController returns a new *Controller.
@@ -141,8 +173,8 @@ func NewController(
 	c.nqosNamespaceLister = namespaceInformer.Lister()
 	c.nqosNamespaceSynced = namespaceInformer.Informer().HasSynced
 	c.nqosNamespaceQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
-		workqueue.TypedRateLimitingQueueConfig[string]{Name: "nqosNamespaces"},
+		workqueue.NewTypedItemFastSlowRateLimiter[*eventData[*corev1.Namespace]](1*time.Second, 5*time.Second, 5),
+		workqueue.TypedRateLimitingQueueConfig[*eventData[*corev1.Namespace]]{Name: "nqosNamespaces"},
 	)
 	_, err = namespaceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onNQOSNamespaceAdd,
@@ -157,8 +189,8 @@ func NewController(
 	c.nqosPodLister = podInformer.Lister()
 	c.nqosPodSynced = podInformer.Informer().HasSynced
 	c.nqosPodQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
-		workqueue.TypedRateLimitingQueueConfig[string]{Name: "nqosPods"},
+		workqueue.NewTypedItemFastSlowRateLimiter[*eventData[*corev1.Pod]](1*time.Second, 5*time.Second, 5),
+		workqueue.TypedRateLimitingQueueConfig[*eventData[*corev1.Pod]]{Name: "nqosPods"},
 	)
 	_, err = podInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onNQOSPodAdd,
@@ -346,22 +378,35 @@ func (c *Controller) onNQOSDelete(obj interface{}) {
 
 // onNQOSNamespaceAdd queues the namespace for processing.
 func (c *Controller) onNQOSNamespaceAdd(obj interface{}) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
+	ns, ok := obj.(*corev1.Namespace)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting Namespace but received %T", obj))
 		return
 	}
-	c.nqosNamespaceQueue.Add(key)
+	if ns == nil {
+		utilruntime.HandleError(fmt.Errorf("empty namespace"))
+		return
+	}
+	c.nqosNamespaceQueue.Add(newEventData(nil, ns))
 }
 
 // onNQOSNamespaceUpdate queues the namespace for processing.
 func (c *Controller) onNQOSNamespaceUpdate(oldObj, newObj interface{}) {
-	oldNamespace := oldObj.(*corev1.Namespace)
-	newNamespace := newObj.(*corev1.Namespace)
-
-	// don't process resync or objects that are marked for deletion
-	if oldNamespace.ResourceVersion == newNamespace.ResourceVersion ||
-		!newNamespace.GetDeletionTimestamp().IsZero() {
+	oldNamespace, ok := oldObj.(*corev1.Namespace)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting Namespace but received %T", oldObj))
+		return
+	}
+	newNamespace, ok := newObj.(*corev1.Namespace)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting Namespace but received %T", newObj))
+		return
+	}
+	if oldNamespace == nil || newNamespace == nil {
+		utilruntime.HandleError(fmt.Errorf("empty namespace"))
+		return
+	}
+	if oldNamespace.ResourceVersion == newNamespace.ResourceVersion || !newNamespace.GetDeletionTimestamp().IsZero() {
 		return
 	}
 	// If the labels have not changed, then there's no change that we care about: return.
@@ -370,41 +415,63 @@ func (c *Controller) onNQOSNamespaceUpdate(oldObj, newObj interface{}) {
 	if labels.Equals(oldNamespaceLabels, newNamespaceLabels) {
 		return
 	}
-	key, err := cache.MetaNamespaceKeyFunc(newObj)
-	if err == nil {
-		klog.V(5).Infof("Updating Namespace in Network QoS controller %s: "+
-			"namespaceLabels: %v", key, newNamespaceLabels)
-		c.nqosNamespaceQueue.Add(key)
-	}
+	klog.V(5).Infof("Namespace %s labels have changed: %v", newNamespace.Name, newNamespaceLabels)
+	c.nqosNamespaceQueue.Add(newEventData(oldNamespace, newNamespace))
 }
 
 // onNQOSNamespaceDelete queues the namespace for processing.
 func (c *Controller) onNQOSNamespaceDelete(obj interface{}) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
-		return
+	ns, ok := obj.(*corev1.Namespace)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		ns, ok = tombstone.Obj.(*corev1.Namespace)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Namespace: %#v", tombstone.Obj))
+			return
+		}
 	}
-	klog.V(5).Infof("Deleting Namespace in Network QoS %s", key)
-	c.nqosNamespaceQueue.Add(key)
+	if ns != nil {
+		c.nqosNamespaceQueue.Add(newEventData(ns, nil))
+	}
 }
 
 // onNQOSPodAdd queues the pod for processing.
 func (c *Controller) onNQOSPodAdd(obj interface{}) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting Pod but received %T", obj))
 		return
 	}
-	klog.V(5).Infof("Adding Pod in Network QoS controller %s", key)
-	c.nqosPodQueue.Add(key)
+	if pod == nil {
+		utilruntime.HandleError(fmt.Errorf("empty pod"))
+		return
+	}
+	if !c.isPodScheduledinLocalZone(pod) {
+		return
+	}
+	c.nqosPodQueue.Add(newEventData(nil, pod))
 }
 
 // onNQOSPodUpdate queues the pod for processing.
 func (c *Controller) onNQOSPodUpdate(oldObj, newObj interface{}) {
-	oldPod := oldObj.(*corev1.Pod)
-	newPod := newObj.(*corev1.Pod)
-
+	oldPod, ok := oldObj.(*corev1.Pod)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting Pod but received %T", oldObj))
+		return
+	}
+	newPod, ok := newObj.(*corev1.Pod)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting Pod but received %T", newObj))
+		return
+	}
+	if oldPod == nil || newPod == nil {
+		utilruntime.HandleError(fmt.Errorf("empty pod"))
+		return
+	}
 	// don't process resync or objects that are marked for deletion
 	if oldPod.ResourceVersion == newPod.ResourceVersion ||
 		!newPod.GetDeletionTimestamp().IsZero() {
@@ -426,34 +493,53 @@ func (c *Controller) onNQOSPodUpdate(oldObj, newObj interface{}) {
 		oldPodCompleted == newPodCompleted {
 		return
 	}
-	key, err := cache.MetaNamespaceKeyFunc(newObj)
-	if err == nil {
-		klog.V(5).Infof("Updating Pod in Network QoS controller %s: "+
-			"podLabels %v, podIPs: %v, PodCompleted?: %v", key, newPodLabels,
-			newPodIPs, newPodCompleted)
-		c.nqosPodQueue.Add(key)
+	// pod not in local zone, no need to process
+	if !c.isPodScheduledinLocalZone(oldPod) && !c.isPodScheduledinLocalZone(newPod) {
+		return
 	}
+	klog.V(5).Infof("Handling update event for pod %s/%s, labels %v, podIPs: %v, PodCompleted?: %v", newPod.Namespace, newPod.Name, newPodLabels, newPodIPs, newPodCompleted)
+	c.nqosPodQueue.Add(newEventData(oldPod, newPod))
 }
 
 // onNQOSPodDelete queues the pod for processing.
 func (c *Controller) onNQOSPodDelete(obj interface{}) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
-		return
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		pod, ok = tombstone.Obj.(*corev1.Pod)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Pod: %#v", tombstone.Obj))
+			return
+		}
 	}
-	klog.V(5).Infof("Deleting Pod Network QoS %s", key)
-	c.nqosPodQueue.Add(key)
+	if pod != nil {
+		c.nqosPodQueue.Add(newEventData(pod, nil))
+	}
 }
 
 // onNQOSNodeUpdate queues the node for processing.
 func (c *Controller) onNQOSNodeUpdate(oldObj, newObj interface{}) {
-	oldNode := oldObj.(*corev1.Node)
-	newNode := newObj.(*corev1.Node)
-
+	oldNode, ok := oldObj.(*corev1.Node)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting Node but received %T", oldObj))
+		return
+	}
+	newNode, ok := newObj.(*corev1.Node)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting Node but received %T", newObj))
+		return
+	}
 	// don't process resync or objects that are marked for deletion
 	if oldNode.ResourceVersion == newNode.ResourceVersion ||
 		!newNode.GetDeletionTimestamp().IsZero() {
+		return
+	}
+	// node not in local zone, no need to process
+	if !c.isNodeInLocalZone(oldNode) && !c.isNodeInLocalZone(newNode) {
 		return
 	}
 	// only care about node's zone name changes

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_namespace.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_namespace.go
@@ -6,130 +6,179 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+
+	nqosv1alpha1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/networkqos/v1alpha1"
+	crdtypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/types"
 )
 
 func (c *Controller) processNextNQOSNamespaceWorkItem(wg *sync.WaitGroup) bool {
 	wg.Add(1)
 	defer wg.Done()
-	nqosNSKey, quit := c.nqosNamespaceQueue.Get()
-	if quit {
+	eventData, shutdown := c.nqosNamespaceQueue.Get()
+	if shutdown {
 		return false
 	}
-	defer c.nqosNamespaceQueue.Done(nqosNSKey)
+	defer c.nqosNamespaceQueue.Done(eventData)
 
-	err := c.syncNetworkQoSNamespace(nqosNSKey)
-	if err == nil {
-		c.nqosNamespaceQueue.Forget(nqosNSKey)
-		return true
+	if err := c.syncNetworkQoSNamespace(eventData); err != nil {
+		if c.nqosNamespaceQueue.NumRequeues(eventData) < maxRetries {
+			klog.Errorf("%s: Failed to reconcile namespace %s: %v", c.controllerName, eventData.name(), err)
+			c.nqosNamespaceQueue.AddRateLimited(eventData)
+			return true
+		}
+		utilruntime.HandleError(fmt.Errorf("failed to reconcile namespace %s: %v", eventData.name(), err))
 	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with: %v", nqosNSKey, err))
-
-	if c.nqosNamespaceQueue.NumRequeues(nqosNSKey) < maxRetries {
-		c.nqosNamespaceQueue.AddRateLimited(nqosNSKey)
-		return true
-	}
-
-	c.nqosNamespaceQueue.Forget(nqosNSKey)
+	c.nqosNamespaceQueue.Forget(eventData)
 	return true
 }
 
-// syncNetworkQoSNamespace decides the main logic everytime
-// we dequeue a key from the nqosNamespaceQueue cache
-func (c *Controller) syncNetworkQoSNamespace(key string) error {
+// syncNetworkQoSNamespace checks if the namespace change affects any NetworkQoS
+func (c *Controller) syncNetworkQoSNamespace(eventData *eventData[*corev1.Namespace]) error {
 	startTime := time.Now()
-	klog.V(5).Infof("Processing sync for Namespace %s in Network QoS controller", key)
+	klog.V(5).Infof("Reconciling namespace event for %s ", eventData.name())
 	defer func() {
-		klog.V(5).Infof("Finished syncing Namespace %s Network QoS controller: took %v", key, time.Since(startTime))
+		klog.V(5).Infof("Finished reconciling namespace %s, took %v", eventData.name(), time.Since(startTime))
 	}()
-	namespace, err := c.nqosNamespaceLister.Get(key)
-	if err != nil && !apierrors.IsNotFound(err) {
+	nqosNames, err := c.getNetworkQosForNamespaceChange(eventData)
+	if err != nil {
 		return err
 	}
-	// (i) namespace add
-	// (ii) namespace update because namespace's labels changed
-	// (iii) namespace delete
-	// case (iii)
-	if namespace == nil {
-		for _, cachedKey := range c.nqosCache.GetKeys() {
-			err := c.nqosCache.DoWithLock(cachedKey, func(nqosKey string) error {
-				if nqosObj, _ := c.nqosCache.Load(nqosKey); nqosObj != nil {
-					return c.clearNamespaceForNQOS(key, nqosObj)
-				}
-				return nil
-			})
-			if err != nil {
-				return err
-			}
-		}
-		recordNamespaceReconcileDuration(c.controllerName, time.Since(startTime).Milliseconds())
-		return nil
-	}
-	// case (i)/(ii)
-	for _, cachedKey := range c.nqosCache.GetKeys() {
-		err := c.nqosCache.DoWithLock(cachedKey, func(nqosKey string) error {
-			if nqosObj, _ := c.nqosCache.Load(nqosKey); nqosObj != nil {
-				return c.setNamespaceForNQOS(namespace, nqosObj)
-			} else {
-				klog.Warningf("NetworkQoS not synced yet: %s", nqosKey)
-				// requeue nqos key to sync it
-				c.nqosQueue.Add(nqosKey)
-				// requeue namespace key 3 seconds later, allow NetworkQoS to be handled
-				c.nqosNamespaceQueue.AddAfter(key, 3*time.Second)
-				return nil
-			}
-		})
-		if err != nil {
-			return err
-		}
+	for nqosName := range nqosNames {
+		c.nqosQueue.Add(nqosName)
 	}
 	recordNamespaceReconcileDuration(c.controllerName, time.Since(startTime).Milliseconds())
 	return nil
 }
 
-// clearNamespaceForNQOS will handle the logic for figuring out if the provided namespace name
-// has pods that affect address sets of the cached network qoses. If so, remove them.
-func (c *Controller) clearNamespaceForNQOS(namespace string, nqosState *networkQoSState) error {
-	for _, rule := range nqosState.EgressRules {
-		if rule.Classifier == nil {
+// getNetworkQosForNamespaceChange returns the set of NetworkQoS names that are affected by the namespace change
+func (c *Controller) getNetworkQosForNamespaceChange(eventData *eventData[*corev1.Namespace]) (sets.Set[string], error) {
+	nqosNames := sets.Set[string]{}
+	nqoses, err := c.getAllNetworkQoSes()
+	if err != nil {
+		return nil, err
+	}
+	for _, nqos := range nqoses {
+		ns := eventData.new
+		if ns == nil {
+			ns = eventData.old
+		}
+		// check if any network selector matches the namespace, or ns label change affects the network selection
+		if namespaceMatchesNetworkSelector(ns, nqos) || networkSelectionChanged(nqos, eventData.new, eventData.old) {
+			nqosNames.Insert(joinMetaNamespaceAndName(nqos.Namespace, nqos.Name))
 			continue
 		}
-		for _, dest := range rule.Classifier.Destinations {
-			if err := dest.removePodsInNamespace(namespace); err != nil {
-				return fmt.Errorf("error removing IPs from dest address set %s: %v", dest.DestAddrSet.GetName(), err)
-			}
+		// check if any egress rule matches the namespace, or ns label change affects the egress selection
+		if namespaceMatchesEgressRule(ns, nqos) || egressSelectionChanged(nqos, eventData.new, eventData.old) {
+			nqosNames.Insert(joinMetaNamespaceAndName(nqos.Namespace, nqos.Name))
 		}
 	}
-	return nil
+	return nqosNames, nil
 }
 
-// setNamespaceForNQOS will handle the logic for figuring out if the provided namespace name
-// has pods that need to populate or removed from the address sets of the network qoses.
-func (c *Controller) setNamespaceForNQOS(namespace *corev1.Namespace, nqosState *networkQoSState) error {
-	for _, rule := range nqosState.EgressRules {
-		if rule.Classifier == nil {
+// namespaceMatchesNetworkSelector checks if the namespace matches any of the network selectors in the NetworkQoS
+func namespaceMatchesNetworkSelector(namespace *corev1.Namespace, nqos *nqosv1alpha1.NetworkQoS) bool {
+	for _, selector := range nqos.Spec.NetworkSelectors {
+		var nsSelector *metav1.LabelSelector
+		switch {
+		case selector.NetworkAttachmentDefinitionSelector != nil:
+			if selector.NetworkAttachmentDefinitionSelector.NamespaceSelector.Size() == 0 {
+				// namespace selector is empty, match all
+				return true
+			}
+			nsSelector = &selector.NetworkAttachmentDefinitionSelector.NamespaceSelector
+			/*case selector.PrimaryUserDefinedNetworkSelector != nil:
+				if selector.PrimaryUserDefinedNetworkSelector.NamespaceSelector.Size() == 0 {
+					// namespace selector is empty, match all
+					return true
+				}
+				nsSelector = &selector.PrimaryUserDefinedNetworkSelector.NamespaceSelector
+			case selector.SecondaryUserDefinedNetworkSelector != nil:
+				if selector.SecondaryUserDefinedNetworkSelector.NamespaceSelector.Size() == 0 {
+					// namespace selector is empty, match all
+					return true
+				}
+				nsSelector = &selector.SecondaryUserDefinedNetworkSelector.NamespaceSelector
+			*/
+		}
+		if nsSelector == nil {
 			continue
 		}
-		for index, dest := range rule.Classifier.Destinations {
-			if dest.PodSelector == nil && dest.NamespaceSelector == nil {
-				// no selectors, no address set
-				continue
-			}
-			if !dest.matchNamespace(namespace, nqosState.namespace) {
-				if err := dest.removePodsInNamespace(namespace.Name); err != nil {
-					return fmt.Errorf("error removing pods in namespace %s from NetworkQoS %s/%s rule %d: %v", namespace.Name, nqosState.namespace, nqosState.name, index, err)
-				}
-				continue
-			}
-			// add matching pods in the namespace to dest
-			if err := dest.addPodsInNamespace(c, namespace.Name); err != nil {
-				return err
-			}
-			klog.V(5).Infof("Added pods in namespace %s for NetworkQoS %s/%s rule %d", namespace.Name, nqosState.namespace, nqosState.name, index)
+		if ls, err := metav1.LabelSelectorAsSelector(nsSelector); err != nil {
+			klog.Errorf("%s/%s - failed to convert namespace selector %s : %v", nqos.Namespace, nqos.Name, nsSelector.String(), err)
+		} else if ls != nil && ls.Matches(labels.Set(namespace.Labels)) {
+			return true
 		}
 	}
-	return nil
+	return false
+}
+
+func namespaceMatchesEgressRule(namespace *corev1.Namespace, nqos *nqosv1alpha1.NetworkQoS) bool {
+	for _, egress := range nqos.Spec.Egress {
+		for _, dest := range egress.Classifier.To {
+			if dest.NamespaceSelector == nil || dest.NamespaceSelector.Size() == 0 {
+				// namespace selector is empty, match all
+				return true
+			}
+			if ls, err := metav1.LabelSelectorAsSelector(dest.NamespaceSelector); err != nil {
+				klog.Errorf("%s/%s - failed to convert egress namespace selector %s: %v", nqos.Namespace, nqos.Name, dest.NamespaceSelector.String(), err)
+			} else if ls != nil && ls.Matches(labels.Set(namespace.Labels)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// check if namespace change causes the network selection change
+func networkSelectionChanged(nqos *nqosv1alpha1.NetworkQoS, new *corev1.Namespace, old *corev1.Namespace) bool {
+	for _, selector := range nqos.Spec.NetworkSelectors {
+		var nsSelector *metav1.LabelSelector
+		switch selector.NetworkSelectionType {
+		/*case crdtypes.PrimaryUserDefinedNetworks:
+			if selector.PrimaryUserDefinedNetworkSelector != nil {
+				nsSelector = &selector.PrimaryUserDefinedNetworkSelector.NamespaceSelector
+			}
+		case crdtypes.SecondaryUserDefinedNetworks:
+			if selector.SecondaryUserDefinedNetworkSelector != nil {
+				nsSelector = &selector.SecondaryUserDefinedNetworkSelector.NamespaceSelector
+			}
+		*/
+		case crdtypes.NetworkAttachmentDefinitions:
+			if selector.NetworkAttachmentDefinitionSelector != nil {
+				nsSelector = &selector.NetworkAttachmentDefinitionSelector.NamespaceSelector
+			}
+		}
+		if nsSelector == nil {
+			continue
+		}
+		if ls, err := metav1.LabelSelectorAsSelector(nsSelector); err != nil {
+			// namespace selector is not valid, skip this selector
+			klog.Errorf("%s/%s - failed to convert namespace selector %s: %v", nqos.Namespace, nqos.Name, nsSelector.String(), err)
+		} else if old != nil && new != nil {
+			return ls.Matches(labels.Set(old.Labels)) != ls.Matches(labels.Set(new.Labels))
+		}
+	}
+	return false
+}
+
+func egressSelectionChanged(nqos *nqosv1alpha1.NetworkQoS, new *corev1.Namespace, old *corev1.Namespace) bool {
+	for _, egress := range nqos.Spec.Egress {
+		for _, dest := range egress.Classifier.To {
+			if dest.NamespaceSelector == nil || dest.NamespaceSelector.Size() == 0 {
+				// empty namespace selector won't make difference
+				continue
+			}
+			if nsSelector, err := metav1.LabelSelectorAsSelector(dest.NamespaceSelector); err != nil {
+				klog.Errorf("failed to convert namespace selector in %s/%s: %v", nqos.Namespace, nqos.Name, err)
+			} else if old != nil && new != nil {
+				return nsSelector.Matches(labels.Set(old.Labels)) != nsSelector.Matches(labels.Set(new.Labels))
+			}
+		}
+	}
+	return false
 }

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_node.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_node.go
@@ -6,13 +6,10 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -41,121 +38,26 @@ func (c *Controller) processNextNQOSNodeWorkItem(wg *sync.WaitGroup) bool {
 	return true
 }
 
-// syncNetworkQoSNode decides the main logic everytime
-// we dequeue a key from the nqosNodeQueue cache
+// syncNetworkQoSNode triggers resync of all the NetworkQoSes when a node moves in/out of local zone
 func (c *Controller) syncNetworkQoSNode(key string) error {
 	startTime := time.Now()
-	_, name, err := cache.SplitMetaNamespaceKey(key)
+	_, nodeName, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
 	}
-	klog.V(5).Infof("Processing sync for Node %s in Network QoS controller", name)
+	klog.V(5).Infof("Processing sync for Node %s in Network QoS controller", nodeName)
 
 	defer func() {
-		klog.V(5).Infof("Finished syncing Node %s Network QoS controller: took %v", name, time.Since(startTime))
+		klog.V(5).Infof("Finished syncing Node %s Network QoS controller: took %v", nodeName, time.Since(startTime))
 	}()
-	node, err := c.nqosNodeLister.Get(name)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	if !c.isNodeInLocalZone(node) && c.TopologyType() == types.Layer3Topology {
-		// clean up qos/address set for the node
-		return c.cleanupQoSFromNode(node.Name)
-	}
-	// configure qos for pods on the node
-	pods, err := c.getPodsByNode(node.Name)
-	if err != nil {
-		return err
-	}
-	switchName := c.getLogicalSwitchName(node.Name)
-	_, err = c.findLogicalSwitch(switchName)
-	if err != nil {
-		klog.V(4).Infof("Failed to look up logical switch %s: %v", switchName, err)
-		return err
-	}
-	for _, cachedKey := range c.nqosCache.GetKeys() {
-		err := c.nqosCache.DoWithLock(cachedKey, func(nqosKey string) error {
-			nqosObj, _ := c.nqosCache.Load(nqosKey)
-			if nqosObj == nil {
-				klog.Warningf("NetworkQoS not synced yet: %s", nqosKey)
-				// requeue nqos key to sync it
-				c.nqosQueue.Add(nqosKey)
-				// requeue namespace key 3 seconds later, allow NetworkQoS to be handled
-				c.nqosNamespaceQueue.AddAfter(key, 3*time.Second)
-				return nil
-			}
-			for _, pod := range pods {
-				ns, err := c.nqosNamespaceLister.Get(pod.Namespace)
-				if err != nil {
-					return fmt.Errorf("failed to look up namespace %s: %w", pod.Namespace, err)
-				}
-				if err = c.setPodForNQOS(pod, nqosObj, ns); err != nil {
-					return err
-				}
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	// node moves in/out of local zone, resync all the NetworkQoSes
+	for _, nqosName := range c.nqosCache.GetKeys() {
+		c.nqosQueue.Add(nqosName)
 	}
 	return nil
-}
-
-func (c *Controller) getPodsByNode(nodeName string) ([]*corev1.Pod, error) {
-	pods, err := c.nqosPodLister.List(labels.Everything())
-	if err != nil {
-		return nil, fmt.Errorf("failed to list pods: %w", err)
-	}
-	podsByNode := []*corev1.Pod{}
-	for _, pod := range pods {
-		if util.PodScheduled(pod) && !util.PodWantsHostNetwork(pod) && pod.Spec.NodeName == nodeName {
-			podsByNode = append(podsByNode, pod)
-		}
-	}
-	return podsByNode, nil
 }
 
 // isNodeInLocalZone returns whether the provided node is in a zone local to the zone controller
 func (c *Controller) isNodeInLocalZone(node *corev1.Node) bool {
 	return util.GetNodeZone(node) == c.zone
-}
-
-func (c *Controller) cleanupQoSFromNode(nodeName string) error {
-	switchName := c.getLogicalSwitchName(nodeName)
-	for _, cachedKey := range c.nqosCache.GetKeys() {
-		err := c.nqosCache.DoWithLock(cachedKey, func(nqosKey string) error {
-			nqosObj, _ := c.nqosCache.Load(nqosKey)
-			if nqosObj == nil {
-				klog.V(4).Infof("Expected networkqos %s not found in cache", nqosKey)
-				return nil
-			}
-			pods := []string{}
-			if val, _ := nqosObj.SwitchRefs.Load(switchName); val != nil {
-				pods = val.([]string)
-			}
-			for _, pod := range pods {
-				addrs, _ := nqosObj.Pods.Load(pod)
-				if addrs != nil {
-					err := nqosObj.SrcAddrSet.DeleteAddresses(addrs.([]string))
-					if err != nil {
-						return err
-					}
-				}
-				nqosObj.Pods.Delete(pod)
-			}
-			err := c.removeQoSFromLogicalSwitches(nqosObj, []string{switchName})
-			if err != nil {
-				return err
-			}
-			nqosObj.SwitchRefs.Delete(switchName)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
-		klog.V(4).Infof("Successfully cleaned up qos rules %s from %s", cachedKey, switchName)
-	}
-	return nil
 }

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_ovnnb.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_ovnnb.go
@@ -145,7 +145,7 @@ func (c *Controller) cleanupStaleOvnObjects(qosState *networkQoSState) error {
 			if _, qosInUse := qosState.SwitchRefs.Load(ls.Name); indexWithinRange && qosInUse {
 				continue
 			}
-			qosList := staleSwitchQoSMap[ls.UUID]
+			qosList := staleSwitchQoSMap[ls.Name]
 			if qosList == nil {
 				qosList = []*nbdb.QoS{}
 			}

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_pod.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_pod.go
@@ -7,142 +7,55 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/tools/cache"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	nqosv1alpha1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/networkqos/v1alpha1"
 )
 
 func (c *Controller) processNextNQOSPodWorkItem(wg *sync.WaitGroup) bool {
 	wg.Add(1)
 	defer wg.Done()
-	nqosPodKey, quit := c.nqosPodQueue.Get()
-	if quit {
+	eventData, shutdown := c.nqosPodQueue.Get()
+	if shutdown {
 		return false
 	}
-	defer c.nqosPodQueue.Done(nqosPodKey)
-	err := c.syncNetworkQoSPod(nqosPodKey)
-	if err == nil {
-		c.nqosPodQueue.Forget(nqosPodKey)
-		return true
+	defer c.nqosPodQueue.Done(eventData)
+
+	if err := c.syncNetworkQoSPod(eventData); err != nil {
+		if c.nqosPodQueue.NumRequeues(eventData) < maxRetries {
+			c.nqosPodQueue.AddRateLimited(eventData)
+			return true
+		}
+		klog.Errorf("%s: Failed to reconcile pod %s/%s: %v", c.controllerName, eventData.namespace(), eventData.name(), err)
+		utilruntime.HandleError(fmt.Errorf("failed to reconcile pod %s/%s: %v", eventData.namespace(), eventData.name(), err))
 	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with: %v", nqosPodKey, err))
-
-	if c.nqosPodQueue.NumRequeues(nqosPodKey) < maxRetries {
-		c.nqosPodQueue.AddRateLimited(nqosPodKey)
-		return true
-	}
-
-	c.nqosPodQueue.Forget(nqosPodKey)
+	c.nqosPodQueue.Forget(eventData)
 	return true
 }
 
 // syncNetworkQoSPod decides the main logic everytime
 // we dequeue a key from the nqosPodQueue cache
-func (c *Controller) syncNetworkQoSPod(key string) error {
+func (c *Controller) syncNetworkQoSPod(eventData *eventData[*corev1.Pod]) error {
 	startTime := time.Now()
-	// Iterate all NQOses and check if this namespace start/stops matching
-	// any NQOS and add/remove the setup accordingly. Namespaces can match multiple
-	// NQOses objects, so continue iterating all NQOS objects before finishing.
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	networkQoSNames, err := c.getNetworkQosForPodChange(eventData)
 	if err != nil {
 		return err
 	}
-	klog.V(5).Infof("Processing sync for Pod %s/%s in Network QoS controller", namespace, name)
-
-	defer func() {
-		klog.V(5).Infof("Finished syncing Pod %s/%s Network QoS controller: took %v", namespace, name, time.Since(startTime))
-	}()
-	ns, err := c.nqosNamespaceLister.Get(namespace)
-	if err != nil {
-		return err
-	}
-	podNamespaceLister := c.nqosPodLister.Pods(namespace)
-	pod, err := podNamespaceLister.Get(name)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	// (i) pod add
-	// (ii) pod update because LSP and IPAM is done OR pod's labels changed
-	// (iii) pod update because pod went into completed state
-	// (iv) pod delete
-	// case(iii)/(iv)
-	if pod == nil || util.PodCompleted(pod) {
-		for _, cachedKey := range c.nqosCache.GetKeys() {
-			err := c.nqosCache.DoWithLock(cachedKey, func(nqosKey string) error {
-				if nqosObj, _ := c.nqosCache.Load(nqosKey); nqosObj != nil {
-					return c.clearPodForNQOS(namespace, name, nqosObj)
-				}
-				return nil
-			})
-			if err != nil {
-				return err
-			}
-		}
-		recordPodReconcileDuration(c.controllerName, time.Since(startTime).Milliseconds())
-		return nil
-	}
-	// We don't want to shortcut only local zone pods here since peer pods
-	// whether local or remote need to be dealt with. So we let the main
-	// NQOS controller take care of the local zone pods logic for the policy subjects
-	if !util.PodScheduled(pod) || util.PodWantsHostNetwork(pod) {
-		// we don't support NQOS with host-networked pods
-		// if pod is no scheduled yet, return and we can process it on its next update
-		// because anyways at that stage pod is considered to belong to remote zone
-		return nil
-	}
-	// case (i)/(ii)
-	for _, cachedKey := range c.nqosCache.GetKeys() {
-		err := c.nqosCache.DoWithLock(cachedKey, func(nqosKey string) error {
-			if nqosObj, _ := c.nqosCache.Load(nqosKey); nqosObj != nil {
-				return c.setPodForNQOS(pod, nqosObj, ns)
-			} else {
-				klog.Warningf("NetworkQoS not synced yet: %s", nqosKey)
-				// requeue nqos key to sync it
-				c.nqosQueue.Add(nqosKey)
-				// requeue pod key in 3 sec
-				c.nqosPodQueue.AddAfter(key, 3*time.Second)
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	for nqosName := range networkQoSNames {
+		c.nqosQueue.Add(nqosName)
 	}
 	recordPodReconcileDuration(c.controllerName, time.Since(startTime).Milliseconds())
-	return nil
-}
-
-// clearPodForNQOS will handle the logic for figuring out if the provided pod name
-func (c *Controller) clearPodForNQOS(namespace, name string, nqosState *networkQoSState) error {
-	fullPodName := joinMetaNamespaceAndName(namespace, name)
-	if err := nqosState.removePodFromSource(c, fullPodName, nil); err != nil {
-		return err
-	}
-	// remove pod from destination address set
-	for _, rule := range nqosState.EgressRules {
-		if rule.Classifier == nil {
-			continue
-		}
-		for _, dest := range rule.Classifier.Destinations {
-			if dest.PodSelector == nil && dest.NamespaceSelector == nil {
-				continue
-			}
-			if err := dest.removePod(fullPodName, nil); err != nil {
-				return err
-			}
-		}
-	}
 	return nil
 }
 
 // setPodForNQOS will check if the pod meets source selector or dest selector
 // - match source: add the ip to source address set, bind qos rule to the switch
 // - match dest: add the ip to the destination address set
-func (c *Controller) setPodForNQOS(pod *corev1.Pod, nqosState *networkQoSState, namespace *corev1.Namespace) error {
+func (c *Controller) setPodForNQOS(pod *corev1.Pod, nqosState *networkQoSState, namespace *corev1.Namespace, addressSetMap map[string]sets.Set[string]) error {
 	addresses, err := getPodAddresses(pod, c.NetInfo)
 	if err == nil && len(addresses) == 0 {
 		// pod either is not attached to this network, or hasn't been annotated with addresses yet, return without retry
@@ -156,7 +69,9 @@ func (c *Controller) setPodForNQOS(pod *corev1.Pod, nqosState *networkQoSState, 
 	if c.isPodScheduledinLocalZone(pod) {
 		if matchSource := nqosState.matchSourceSelector(pod); matchSource {
 			// pod's labels match source selector
-			err = nqosState.configureSourcePod(c, pod, addresses)
+			if err = nqosState.configureSourcePod(c, pod, addresses); err == nil {
+				populateAddresses(addressSetMap, nqosState.SrcAddrSet.GetName(), addresses)
+			}
 		} else {
 			// pod's labels don't match selector, but it probably matched previously
 			err = nqosState.removePodFromSource(c, fullPodName, addresses)
@@ -171,10 +86,10 @@ func (c *Controller) setPodForNQOS(pod *corev1.Pod, nqosState *networkQoSState, 
 			return err
 		}
 	}
-	return reconcilePodForDestinations(nqosState, namespace, pod, addresses)
+	return reconcilePodForDestinations(nqosState, namespace, pod, addresses, addressSetMap)
 }
 
-func reconcilePodForDestinations(nqosState *networkQoSState, podNs *corev1.Namespace, pod *corev1.Pod, addresses []string) error {
+func reconcilePodForDestinations(nqosState *networkQoSState, podNs *corev1.Namespace, pod *corev1.Pod, addresses []string, addressSetMap map[string]sets.Set[string]) error {
 	fullPodName := joinMetaNamespaceAndName(pod.Namespace, pod.Name)
 	for _, rule := range nqosState.EgressRules {
 		for index, dest := range rule.Classifier.Destinations {
@@ -186,6 +101,7 @@ func reconcilePodForDestinations(nqosState *networkQoSState, podNs *corev1.Names
 				if err := dest.addPod(pod.Namespace, pod.Name, addresses); err != nil {
 					return fmt.Errorf("failed to add addresses {%s} to dest address set %s for NetworkQoS %s/%s, rule index %d: %v", strings.Join(addresses, ","), dest.DestAddrSet.GetName(), nqosState.namespace, nqosState.name, index, err)
 				}
+				populateAddresses(addressSetMap, dest.DestAddrSet.GetName(), addresses)
 			} else {
 				// no match, remove the pod if it's previously selected
 				if err := dest.removePod(fullPodName, addresses); err != nil {
@@ -195,4 +111,127 @@ func reconcilePodForDestinations(nqosState *networkQoSState, podNs *corev1.Names
 		}
 	}
 	return nil
+}
+
+func (c *Controller) getNetworkQosForPodChange(eventData *eventData[*corev1.Pod]) (sets.Set[string], error) {
+	var pod *corev1.Pod
+	if eventData.new != nil {
+		pod = eventData.new
+	} else {
+		pod = eventData.old
+	}
+	podNs, err := c.nqosNamespaceLister.Get(pod.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get namespace %s: %v", pod.Namespace, err)
+	}
+	nqoses, err := c.getAllNetworkQoSes()
+	if err != nil {
+		return nil, err
+	}
+	affectedNetworkQoSes := sets.Set[string]{}
+	for _, nqos := range nqoses {
+		if podMatchesSourceSelector(pod, nqos) {
+			affectedNetworkQoSes.Insert(joinMetaNamespaceAndName(nqos.Namespace, nqos.Name))
+			continue
+		}
+		// check if pod matches any egress
+		for _, egress := range nqos.Spec.Egress {
+			if podMatchesEgressSelector(podNs, pod, nqos, &egress) {
+				affectedNetworkQoSes.Insert(joinMetaNamespaceAndName(nqos.Namespace, nqos.Name))
+				continue
+			}
+		}
+		if podSelectionChanged(nqos, eventData.new, eventData.old) {
+			affectedNetworkQoSes.Insert(joinMetaNamespaceAndName(nqos.Namespace, nqos.Name))
+		}
+	}
+	return affectedNetworkQoSes, nil
+}
+
+func podMatchesSourceSelector(pod *corev1.Pod, nqos *nqosv1alpha1.NetworkQoS) bool {
+	if nqos.Namespace != pod.Namespace {
+		return false
+	}
+	if nqos.Spec.PodSelector.Size() == 0 {
+		return true
+	}
+	podSelector, err := metav1.LabelSelectorAsSelector(&nqos.Spec.PodSelector)
+	if err != nil {
+		klog.Errorf("failed to convert pod selector in %s/%s: %v", nqos.Namespace, nqos.Name, err)
+		return false
+	}
+	return podSelector.Matches(labels.Set(pod.Labels))
+}
+
+func podMatchesEgressSelector(podNs *corev1.Namespace, pod *corev1.Pod, nqos *nqosv1alpha1.NetworkQoS, egress *nqosv1alpha1.Rule) bool {
+	var nsSelector labels.Selector
+	var podSelector labels.Selector
+	var err error
+	match := false
+	for _, dest := range egress.Classifier.To {
+		if dest.NamespaceSelector != nil {
+			if nsSelector, err = metav1.LabelSelectorAsSelector(dest.NamespaceSelector); err != nil {
+				klog.Errorf("failed to convert namespace selector in %s/%s: %v", nqos.Namespace, nqos.Name, err)
+				continue
+			}
+		}
+		if dest.PodSelector != nil {
+			if podSelector, err = metav1.LabelSelectorAsSelector(dest.PodSelector); err != nil {
+				klog.Errorf("failed to convert pod selector in %s/%s: %v", nqos.Namespace, nqos.Name, err)
+				continue
+			}
+		}
+		switch {
+		case nsSelector != nil && podSelector != nil:
+			match = nsSelector.Matches(labels.Set(podNs.Labels)) && podSelector.Matches(labels.Set(pod.Labels))
+		case nsSelector == nil && podSelector != nil:
+			match = pod.Namespace == nqos.Namespace && podSelector.Matches(labels.Set(pod.Labels))
+		case nsSelector != nil && podSelector == nil:
+			match = nsSelector.Matches(labels.Set(podNs.Labels))
+		default: //nsSelector == nil && podSelector == nil:
+			match = false
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func podSelectionChanged(nqos *nqosv1alpha1.NetworkQoS, new *corev1.Pod, old *corev1.Pod) bool {
+	if new == nil || old == nil {
+		return false
+	}
+	if nqos.Spec.PodSelector.Size() > 0 {
+		if podSelector, err := metav1.LabelSelectorAsSelector(&nqos.Spec.PodSelector); err != nil {
+			klog.Errorf("failed to convert pod selector in %s/%s: %v", nqos.Namespace, nqos.Name, err)
+		} else if podSelector.Matches(labels.Set(new.Labels)) != podSelector.Matches(labels.Set(old.Labels)) {
+			return true
+		}
+	}
+	for _, egress := range nqos.Spec.Egress {
+		for _, dest := range egress.Classifier.To {
+			if dest.PodSelector == nil {
+				continue
+			}
+			if podSelector, err := metav1.LabelSelectorAsSelector(dest.PodSelector); err != nil {
+				klog.Errorf("failed to convert pod selector in %s/%s: %v", nqos.Namespace, nqos.Name, err)
+			} else if podSelector.Matches(labels.Set(new.Labels)) != podSelector.Matches(labels.Set(old.Labels)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func populateAddresses(addressSetMap map[string]sets.Set[string], name string, addresses []string) {
+	if len(addresses) == 0 {
+		return
+	}
+	addressSet := addressSetMap[name]
+	if addressSet == nil {
+		addressSet = sets.New[string]()
+	}
+	addressSet.Insert(addresses...)
+	addressSetMap[name] = addressSet
 }

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_test.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_test.go
@@ -207,7 +207,7 @@ func tableEntrySetup(enableInterconnect bool) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node1",
 			Annotations: map[string]string{
-				"k8s.ovn.org/zone-name": "node1",
+				"k8s.ovn.org/zone-name": "zone1",
 			},
 		},
 	}
@@ -216,7 +216,7 @@ func tableEntrySetup(enableInterconnect bool) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node2",
 			Annotations: map[string]string{
-				"k8s.ovn.org/zone-name": "node2",
+				"k8s.ovn.org/zone-name": "zone1",
 			},
 		},
 	}
@@ -902,8 +902,8 @@ func initNetworkQoSController(netInfo util.NetInfo, addrsetFactory addressset.Ad
 		watchFactory.NADInformer(),
 		addrsetFactory,
 		func(pod *corev1.Pod) bool {
-			return pod.Spec.NodeName == "node1"
-		}, "node1")
+			return true
+		}, "zone1")
 	Expect(err).NotTo(HaveOccurred())
 	err = watchFactory.Start()
 	Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/ovn/controller/network_qos/repair.go
+++ b/go-controller/pkg/ovn/controller/network_qos/repair.go
@@ -1,10 +1,8 @@
 package networkqos
 
 import (
-	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 
 	networkqosapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/networkqos/v1alpha1"
@@ -20,9 +18,9 @@ func (c *Controller) repairNetworkQoSes() error {
 	defer func() {
 		klog.Infof("Repairing network qos took %v", time.Since(start))
 	}()
-	nqoses, err := c.nqosLister.List(labels.Everything())
+	nqoses, err := c.getAllNetworkQoSes()
 	if err != nil {
-		return fmt.Errorf("unable to list NetworkQoSes from the lister: %v", err)
+		return err
 	}
 	nqosMap := map[string]*networkqosapi.NetworkQoS{}
 	for _, nqos := range nqoses {

--- a/go-controller/pkg/ovn/controller/network_qos/types.go
+++ b/go-controller/pkg/ovn/controller/network_qos/types.go
@@ -11,8 +11,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
@@ -65,7 +65,6 @@ func (nqosState *networkQoSState) initAddressSets(addressSetFactory addressset.A
 	if err != nil {
 		return fmt.Errorf("failed to init source address set for %s/%s: %w", nqosState.namespace, nqosState.name, err)
 	}
-
 	// ensure destination address sets
 	for ruleIndex, rule := range nqosState.EgressRules {
 		for destIndex, dest := range rule.Classifier.Destinations {
@@ -191,6 +190,40 @@ func (nqosState *networkQoSState) getAddressSetHashNames() []string {
 	return addrsetNames
 }
 
+func (nqosState *networkQoSState) cleanupStaleAddresses(addressSetMap map[string]sets.Set[string]) {
+	if nqosState.SrcAddrSet != nil {
+		addresses := addressSetMap[nqosState.SrcAddrSet.GetName()]
+		v4Addresses, _ := nqosState.SrcAddrSet.GetAddresses()
+		staleAddresses := []string{}
+		for _, address := range v4Addresses {
+			if !addresses.Has(address) {
+				staleAddresses = append(staleAddresses, address)
+			}
+		}
+		if len(staleAddresses) > 0 {
+			nqosState.SrcAddrSet.DeleteAddresses(staleAddresses)
+		}
+	}
+	for _, egress := range nqosState.EgressRules {
+		for _, dest := range egress.Classifier.Destinations {
+			if dest.DestAddrSet == nil {
+				continue
+			}
+			addresses := addressSetMap[dest.DestAddrSet.GetName()]
+			v4Addresses, _ := dest.DestAddrSet.GetAddresses()
+			staleAddresses := []string{}
+			for _, address := range v4Addresses {
+				if !addresses.Has(address) {
+					staleAddresses = append(staleAddresses, address)
+				}
+			}
+			if len(staleAddresses) > 0 {
+				dest.DestAddrSet.DeleteAddresses(staleAddresses)
+			}
+		}
+	}
+}
+
 type GressRule struct {
 	Priority   int
 	Dscp       int
@@ -309,13 +342,6 @@ type Destination struct {
 	NamespaceSelector labels.Selector
 }
 
-func (dest *Destination) matchNamespace(podNs *corev1.Namespace, qosNamespace string) bool {
-	if dest.NamespaceSelector == nil {
-		return podNs.Name == qosNamespace
-	}
-	return dest.NamespaceSelector.Matches(labels.Set(podNs.Labels))
-}
-
 func (dest *Destination) matchPod(podNs *corev1.Namespace, pod *corev1.Pod, qosNamespace string) bool {
 	switch {
 	case dest.NamespaceSelector != nil && dest.PodSelector != nil:
@@ -349,47 +375,6 @@ func (dest *Destination) removePod(fullPodName string, addresses []string) error
 		return fmt.Errorf("failed to remove addresses (%s): %v", strings.Join(addresses, ","), err)
 	}
 	dest.Pods.Delete(fullPodName)
-	return nil
-}
-
-func (dest *Destination) removePodsInNamespace(namespace string) error {
-	var err error
-	// check for pods in the namespace being cleared
-	dest.Pods.Range(func(key, _ any) bool {
-		fullPodName := key.(string)
-		nameParts := strings.Split(fullPodName, "/")
-		if nameParts[0] != namespace {
-			// pod's namespace doesn't match
-			return true
-		}
-		err = dest.removePod(fullPodName, nil)
-		return err == nil
-	})
-	return err
-}
-
-func (dest *Destination) addPodsInNamespace(ctrl *Controller, namespace string) error {
-	podSelector := labels.Everything()
-	if dest.PodSelector != nil {
-		podSelector = dest.PodSelector
-	}
-	pods, err := ctrl.nqosPodLister.Pods(namespace).List(podSelector)
-	if err != nil {
-		if apierrors.IsNotFound(err) || len(pods) == 0 {
-			return nil
-		}
-		return fmt.Errorf("failed to look up pods in ns %s: %v", namespace, err)
-	}
-	klog.V(5).Infof("Found %d pods in namespace %s by selector %s", len(pods), namespace, podSelector.String())
-	for _, pod := range pods {
-		podAddresses, err := getPodAddresses(pod, ctrl.NetInfo)
-		if err != nil {
-			return fmt.Errorf("failed to parse IPs for pod %s/%s: %v", pod.Namespace, pod.Name, err)
-		}
-		if err := dest.addPod(pod.Namespace, pod.Name, podAddresses); err != nil {
-			return fmt.Errorf("failed to add addresses {%s} to address set %s: %v", strings.Join(podAddresses, ","), dest.DestAddrSet.GetName(), err)
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
- namespace/pod/node handlers detect possible changes and trigger reconciliation by putting networkqos in event queue.
- reconcile networkqos rules in networkqos handler only
